### PR TITLE
Wrapped func is recalled when result is None.

### DIFF
--- a/django_request_cache/__init__.py
+++ b/django_request_cache/__init__.py
@@ -45,12 +45,14 @@ def cache_for_request(fn):
 
         # cache found -> check if a result is already available for this function call
         key = cache_calculate_key(fn.__name__, *args, **kwargs)
-        result = getattr(cache, key, None)
 
-        if not result:
+        try:
+            result = getattr(cache, key)
+        except AttributeError:
             # no result available -> execute function
             result = fn(*args, **kwargs)
             setattr(cache, key, result)
 
         return result
     return wrapper
+


### PR DESCRIPTION
`if not result` in L50 recall wrapped function when result is an empty queryset like `queryset.count() == 0`.